### PR TITLE
PA-39 Jenkins module attaches EBS volumes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,12 +31,12 @@ data "aws_route53_zone" "domain" {
 }
 
 module "jenkins_master" {
-  source             = "./modules/jenkins_master"
-  aws_key_pair       = "${var.aws_key_pair}"
-  tool_name          = "jenkins_master"
-  zone_id            = "${data.aws_route53_zone.domain.zone_id}"
-  ssh_sg             = "${aws_security_group.ssh_sg.name}"
-  jenkins_sg         = "${aws_security_group.jenkins_sg.name}"
+  source               = "./modules/jenkins_master"
+  aws_key_pair         = "${var.aws_key_pair}"
+  tool_name            = "jenkins_master"
+  zone_id              = "${data.aws_route53_zone.domain.zone_id}"
+  ssh_sg               = "${aws_security_group.ssh_sg.name}"
+  jenkins_sg           = "${aws_security_group.jenkins_sg.name}"
   inventories_location = "${var.inventories_location}"
 }
 

--- a/modules/jenkins_master/main.tf
+++ b/modules/jenkins_master/main.tf
@@ -8,21 +8,37 @@ variable "zone_id" {}
 variable "ssh_sg" {}
 variable "jenkins_sg" {}
 
+data "aws_ebs_volume" "jenkins_master_volume" {
+  filter {
+    name   = "tag:Name"
+    values = ["jenkins_master_data"]
+  }
+
+  most_recent = true
+}
+
 resource "aws_instance" "jenkins_master" {
-  ami             = "ami-1853ac65"
-  instance_type   = "m5.large"
-  key_name        = "${var.aws_key_pair}"
-  security_groups = ["${var.ssh_sg}", "${var.jenkins_sg}"]
+  ami               = "ami-1853ac65"
+  instance_type     = "m5.large"
+  key_name          = "${var.aws_key_pair}"
+  security_groups   = ["${var.ssh_sg}", "${var.jenkins_sg}"]
+  availability_zone = "us-east-1a"
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = "500"
+    volume_size = "20"
   }
 
   tags {
     Project = "hackathon_pipeline"
     Name    = "${var.tool_name}_hackathon"
   }
+}
+
+resource "aws_volume_attachment" "jenkins_master_data" {
+  device_name = "/dev/sdh"
+  volume_id   = "${data.aws_ebs_volume.jenkins_master_volume.volume_id}"
+  instance_id = "${aws_instance.jenkins_master.id}"
 }
 
 resource "aws_route53_record" "jenkins" {


### PR DESCRIPTION
EBS volumes get mounted. Other terraform configuration creates the EBS volumes for us. This uses the data resource to go and pull the volume ID from AWS directly. This allows us to mount without the terraform configurations needing to be run together or have some scripting in between. 